### PR TITLE
More fixes courtesy of the JSCompiler

### DIFF
--- a/iron-resizable-behavior.html
+++ b/iron-resizable-behavior.html
@@ -110,6 +110,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     },
 
+    // TODO(cdata): Currently behaviors cannot define "abstract" methods.
+    // resizerShouldNotify: function(el) { return true; },
+
     _parentResizableChanged: function(parentResizable) {
       if (parentResizable) {
         window.removeEventListener('resize', this._boundNotifyResize);

--- a/iron-resizable-behavior.html
+++ b/iron-resizable-behavior.html
@@ -30,6 +30,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   Polymer.IronResizableBehavior = {
     properties: {
       _parentResizable: {
+        type: Object,
         observer: '_parentResizableChanged'
       }
     },
@@ -102,27 +103,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
      * that should be notified of a resize change.
      */
     stopResizeNotificationsFor: function(target) {
-      index = this._interestedResizables.indexOf(target);
+      var index = this._interestedResizables.indexOf(target);
 
       if (index > -1) {
         this._interestedResizables.splice(index, 1);
       }
     },
-
-    /**
-     * User should implement to introduce filtering when notifying children.
-     * Generally, children that are hidden by the resizable (e.g. non-active
-     * pages) need not be notified during resize, since they will be notified
-     * again when becoming un-hidden.
-     *
-     * Return `true` if the resizable passed as argument should be notified of
-     * resize.
-     *
-     * @method resizerShouldNotify
-     * @param {Element} el
-     */
-    // TODO(cdata): Currently behaviors cannot define "abstract" methods..
-    //resizerShouldNotify: function(el) { return true; },
 
     _parentResizableChanged: function(parentResizable) {
       if (parentResizable) {


### PR DESCRIPTION
I had to remove the commented out resizerShouldNotify because the compiler was trying to put the JSDocs onto _parentResizableChanged. We can always get it back from git history.
