### PR TITLE
Fix resize events across shadow boundaries

### DIFF
--- a/iron-resizable-behavior.html
+++ b/iron-resizable-behavior.html
@@ -29,9 +29,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
    **/
   Polymer.IronResizableBehavior = {
     properties: {
+      /**
+       * The closest ancestor element that implements `IronResizableBehavior`.
+       */
       _parentResizable: {
         type: Object,
         observer: '_parentResizableChanged'
+      },
+
+      /**
+       * True if this element is currently notifying its descedant elements of
+       * resize.
+       */
+      _notifyingDescendant: {
+        type: Boolean,
+        value: false
       }
     },
 
@@ -49,7 +61,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     attached: function() {
       this.fire('iron-request-resize-notifications', null, {
         node: this,
-        bubbles: true
+        bubbles: true,
+        cancelable: true
       });
 
       if (!this._parentResizable) {
@@ -78,16 +91,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       this._interestedResizables.forEach(function(resizable) {
-        // TODO(cdata): Currently behaviors cannot define "abstract" methods..
-        if (!this.resizerShouldNotify || this.resizerShouldNotify(resizable)) {
-          resizable.notifyResize();
+        if (this.resizerShouldNotify(resizable)) {
+          this._notifyDescendant(resizable);
         }
       }, this);
 
-      this.fire('iron-resize', null, {
-        node: this,
-        bubbles: false
-      });
+      this._fireResize();
     },
 
     /**
@@ -107,16 +116,40 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       if (index > -1) {
         this._interestedResizables.splice(index, 1);
+        this.unlisten(target, 'iron-resize', '_onDescendantIronResize');
       }
     },
 
-    // TODO(cdata): Currently behaviors cannot define "abstract" methods.
-    // resizerShouldNotify: function(el) { return true; },
+    /**
+     * This method can be overridden to filter nested elements that should or
+     * should not be notified by the current element. Return true if an element
+     * should be notified, or false if it should not be notified.
+     *
+     * @param {HTMLElement} element A candidate descendant element that
+     * implements `IronResizableBehavior`.
+     * @return {boolean} True if the `element` should be notified of resize.
+     */
+    resizerShouldNotify: function(element) { return true; },
 
-    _parentResizableChanged: function(parentResizable) {
-      if (parentResizable) {
-        window.removeEventListener('resize', this._boundNotifyResize);
+    _onDescendantIronResize: function(event) {
+      if (this._notifyingDescendant) {
+        event.stopPropagation();
+        return;
       }
+
+      // NOTE(cdata): In ShadowDOM, event retargetting makes echoing of the
+      // otherwise non-bubbling event "just work." We do it manually here for
+      // the case where Polymer is not using shadow roots for whatever reason:
+      if (!Polymer.Settings.useShadow) {
+        this._fireResize();
+      }
+    },
+
+    _fireResize: function() {
+      this.fire('iron-resize', null, {
+        node: this,
+        bubbles: false
+      });
     },
 
     _onIronRequestResizeNotifications: function(event) {
@@ -128,11 +161,32 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       if (this._interestedResizables.indexOf(target) === -1) {
         this._interestedResizables.push(target);
+        this.listen(target, 'iron-resize', '_onDescendantIronResize');
       }
 
       target.assignParentResizable(this);
+      this._notifyDescendant(target);
 
       event.stopPropagation();
+    },
+
+    _parentResizableChanged: function(parentResizable) {
+      if (parentResizable) {
+        window.removeEventListener('resize', this._boundNotifyResize);
+      }
+    },
+
+    _notifyDescendant: function(descendant) {
+      // NOTE(cdata): In IE10, attached is fired on children first, so it's
+      // important not to notify them if the parent is not attached yet (or
+      // else they will get redundantly notified when the parent attaches).
+      if (!this.isAttached) {
+        return;
+      }
+
+      this._notifyingDescendant = true;
+      descendant.notifyResize();
+      this._notifyingDescendant = false;
     }
   };
 </script>

--- a/test/index.html
+++ b/test/index.html
@@ -22,7 +22,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
 
     WCT.loadSuites([
-      'basic.html'
+      'basic.html',
+      'iron-resizable-behavior.html'
     ]);
 
   </script>

--- a/test/iron-resizable-behavior.html
+++ b/test/iron-resizable-behavior.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<html>
+<head>
+
+  <title>iron-resizable-behavior tests</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+  <script src="../../test-fixture/test-fixture-mocha.js"></script>
+
+  <link rel="import" href="../../test-fixture/test-fixture.html">
+  <link rel="import" href="../iron-resizable-behavior.html">
+  <link rel="import" href="test-elements.html">
+
+</head>
+<body>
+ 
+  <test-fixture id="ResizableAndShadowBoundaries">
+    <template>
+      <x-light-resizable></x-light-resizable>
+    </template>
+  </test-fixture>
+
+  <script>
+
+  suite('iron-resizable-behavior', function() {
+    var resizable;
+
+    suite('events across shadow boundaries', function() {
+      setup(function() {
+        resizable = fixture('ResizableAndShadowBoundaries');
+      });
+
+      suite('ancestor\'s iron-resize', function() {
+        test('only fires once for a notifying shadow descendent', function() {
+          resizable.$.childResizable1.notifyResize();
+
+          expect(resizable.ironResizeCount).to.be.equal(2);
+        });
+
+        test('only fires once when notifying descendent observables', function() {
+          resizable.notifyResize();
+
+          expect(resizable.ironResizeCount).to.be.equal(2);
+        });
+      });
+
+      suite('descendant\'s iron-resize', function() {
+        test('only fires once for a notifying shadow root', function() {
+          resizable.notifyResize();
+
+          expect(resizable.$.childResizable1.ironResizeCount).to.be.equal(2);
+          expect(resizable.$.childResizable2.ironResizeCount).to.be.equal(2);
+        });
+
+        test('only fires once for a notifying descendent observable', function() {
+          resizable.$.childResizable1.notifyResize();
+
+          expect(resizable.$.childResizable1.ironResizeCount).to.be.equal(2);
+        });
+      });
+
+      suite('window\'s resize', function() {
+        test('causes all iron-resize events to fire once', function() {
+          window.dispatchEvent(new CustomEvent('resize'));
+          expect(resizable.ironResizeCount).to.be.equal(2);
+          expect(resizable.$.childResizable1.ironResizeCount).to.be.equal(2);
+          expect(resizable.$.childResizable2.ironResizeCount).to.be.equal(2);
+        });
+      });
+    });
+
+  });
+  </script>
+</body>
+</html>

--- a/test/test-elements.html
+++ b/test/test-elements.html
@@ -141,3 +141,53 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   });
 
 </script>
+<script>
+  Polymer.ObserveIronResizeBehavior = {
+    properties: {
+      ironResizeCount: {
+        type: Number,
+        value: 0
+      }
+    },
+
+    listeners: {
+      'iron-resize': '_incrementIronResizeCount'
+    },
+
+    _incrementIronResizeCount: function() {
+      this.ironResizeCount++;
+    }
+  };
+</script>
+<dom-module id="x-shadow-resizable">
+  <template>
+    <div></div>
+  </template>
+</dom-module>
+<script>
+  Polymer({
+    is: 'x-shadow-resizable',
+
+    behaviors: [
+      Polymer.IronResizableBehavior,
+      Polymer.ObserveIronResizeBehavior
+    ]
+  });
+</script>
+
+<dom-module id="x-light-resizable">
+  <template>
+    <x-shadow-resizable id="childResizable1"></x-shadow-resizable>
+    <x-shadow-resizable id="childResizable2"></x-shadow-resizable>
+  </template>
+</dom-module>
+<script>
+  Polymer({
+    is: 'x-light-resizable',
+
+    behaviors: [
+      Polymer.IronResizableBehavior,
+      Polymer.ObserveIronResizeBehavior
+    ]
+  });
+</script>


### PR DESCRIPTION
- Resize events are not doubled anymore due to ShadowDOM retargeting
- Resize events from shadow descendants trigger resize up the tree in
  both ShadowDOM and ShadeyDOM.
