### PR TITLE
2.0 preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-bower_components
+bower_components*
+bower-*.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: node_js
 sudo: required
 before_script:
-  - npm install -g bower polymer-cli@next
+  - npm install -g polymer-cli
   - polymer install --variants
-  - sudo mv /usr/bin/google-chrome /usr/bin/google-chrome-old
-  - sudo mv /usr/bin/google-chrome-beta /usr/bin/google-chrome
 env:
   global:
     - secure: >-
@@ -18,7 +16,7 @@ addons:
     sources:
       - google-chrome
     packages:
-      - google-chrome-beta
+      - google-chrome-stable
 script:
   - xvfb-run polymer test
   - >-

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,25 @@ sudo: required
 before_script:
   - npm install -g bower polymer-cli@next
   - polymer install --variants
+  - sudo mv /usr/bin/google-chrome /usr/bin/google-chrome-old
+  - sudo mv /usr/bin/google-chrome-beta /usr/bin/google-chrome
 env:
   global:
-    - secure: Bsp8pa19FCij3Eee0P5eOE8ZrbylrYL99R9EIxH6rcDH+rxMhK0BIfSiXTPSFRk2iqJp++RIZN8kUu5GddetiXreRZDtnhXBA2QoYteIAS8Hzy9u2EggqI0UdGqbCiFHDVD/rEQyhSPiIfWHGCg/Moeo9J2k/eC2w6I8I9C15Zw=
-    - secure: j9xIW/banUkkNaLrWVGcTsasAp64zEmZJQO+eY8ExINx3uLbDh5h6Foc7xWhJ4Yu7aey3+nH5BWKYimtPTYoXUD2nIWU31yBNbqU/+G6vIppDbgPHMRcVnRiO7YZ0yW1JunvKs+1lOPhOw4ibztJjGkQ2ZK9q6ZSJvQKRbo6Au0=
-node_js: '6'
+    - secure: >-
+        Bsp8pa19FCij3Eee0P5eOE8ZrbylrYL99R9EIxH6rcDH+rxMhK0BIfSiXTPSFRk2iqJp++RIZN8kUu5GddetiXreRZDtnhXBA2QoYteIAS8Hzy9u2EggqI0UdGqbCiFHDVD/rEQyhSPiIfWHGCg/Moeo9J2k/eC2w6I8I9C15Zw=
+    - secure: >-
+        j9xIW/banUkkNaLrWVGcTsasAp64zEmZJQO+eY8ExINx3uLbDh5h6Foc7xWhJ4Yu7aey3+nH5BWKYimtPTYoXUD2nIWU31yBNbqU/+G6vIppDbgPHMRcVnRiO7YZ0yW1JunvKs+1lOPhOw4ibztJjGkQ2ZK9q6ZSJvQKRbo6Au0=
+node_js: stable
 addons:
   firefox: latest
   apt:
     sources:
       - google-chrome
     packages:
-      - google-chrome-stable
+      - google-chrome-beta
 script:
   - xvfb-run polymer test
-  - 'if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then polymer test -s ''default''; fi'
+  - >-
+    if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then polymer test -s 'default';
+    fi
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,12 @@
 language: node_js
 sudo: required
 before_script:
-  - npm install -g bower polylint web-component-tester
-  - bower install
-  - polylint
+  - npm install -g bower polymer-cli@next
+  - polymer install --variants
 env:
   global:
-    - secure: >-
-        Bsp8pa19FCij3Eee0P5eOE8ZrbylrYL99R9EIxH6rcDH+rxMhK0BIfSiXTPSFRk2iqJp++RIZN8kUu5GddetiXreRZDtnhXBA2QoYteIAS8Hzy9u2EggqI0UdGqbCiFHDVD/rEQyhSPiIfWHGCg/Moeo9J2k/eC2w6I8I9C15Zw=
-    - secure: >-
-        j9xIW/banUkkNaLrWVGcTsasAp64zEmZJQO+eY8ExINx3uLbDh5h6Foc7xWhJ4Yu7aey3+nH5BWKYimtPTYoXUD2nIWU31yBNbqU/+G6vIppDbgPHMRcVnRiO7YZ0yW1JunvKs+1lOPhOw4ibztJjGkQ2ZK9q6ZSJvQKRbo6Au0=
+    - secure: Bsp8pa19FCij3Eee0P5eOE8ZrbylrYL99R9EIxH6rcDH+rxMhK0BIfSiXTPSFRk2iqJp++RIZN8kUu5GddetiXreRZDtnhXBA2QoYteIAS8Hzy9u2EggqI0UdGqbCiFHDVD/rEQyhSPiIfWHGCg/Moeo9J2k/eC2w6I8I9C15Zw=
+    - secure: j9xIW/banUkkNaLrWVGcTsasAp64zEmZJQO+eY8ExINx3uLbDh5h6Foc7xWhJ4Yu7aey3+nH5BWKYimtPTYoXUD2nIWU31yBNbqU/+G6vIppDbgPHMRcVnRiO7YZ0yW1JunvKs+1lOPhOw4ibztJjGkQ2ZK9q6ZSJvQKRbo6Au0=
 node_js: '6'
 addons:
   firefox: latest
@@ -19,6 +16,6 @@ addons:
     packages:
       - google-chrome-stable
 script:
-  - xvfb-run wct
-  - 'if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then wct -s ''default''; fi'
+  - xvfb-run polymer test
+  - 'if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then polymer test -s ''default''; fi'
 dist: trusty

--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,6 @@
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#2.0-preview",
-    "test-fixture": "PolymerElements/test-fixture#^3.0.0-rc.1",
     "web-component-tester": "^6.0.0-prerelease.6",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0-rc.1"
   },
@@ -34,7 +33,6 @@
       },
       "devDependencies": {
         "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
-        "test-fixture": "PolymerElements/test-fixture#^1.0.0",
         "web-component-tester": "^4.0.0",
         "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
       }

--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#2.0-preview",
     "test-fixture": "PolymerElements/test-fixture#^2.0.0",
-    "web-component-tester": "^4.0.0",
+    "web-component-tester": "v6.0.0-prerelease.5",
     "webcomponentsjs": "webcomponents/webcomponentsjs#v1"
   },
   "variants": {

--- a/bower.json
+++ b/bower.json
@@ -19,18 +19,18 @@
     "url": "git://github.com/PolymerElements/iron-resizable-behavior.git"
   },
   "dependencies": {
-    "polymer": "https://github.com/PolymerLabs/alacarte.git#master"
+    "polymer": "Polymer/polymer#2.0-preview"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
     "test-fixture": "PolymerElements/test-fixture#custom-elements-v1",
     "web-component-tester": "^4.0.0",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#v1-polymer-edits"
+    "webcomponentsjs": "webcomponents/webcomponentsjs#v1"
   },
   "resolutions": {
-    "polymer": "master",
+    "polymer": "2.0-preview",
     "test-fixture": "custom-elements-v1",
-    "webcomponentsjs": "v1-polymer-edits"
+    "webcomponentsjs": "v1"
   },
   "ignore": []
 }

--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "polymer": "Polymer/polymer#2.0-preview"
   },
   "devDependencies": {
-    "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
+    "iron-component-page": "PolymerElements/iron-component-page#2.0-preview",
     "test-fixture": "PolymerElements/test-fixture#custom-elements-v1",
     "web-component-tester": "^4.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#v1"
@@ -40,10 +40,8 @@
       }
     }
   },
+  "ignore": [],
   "resolutions": {
-    "polymer": "2.0-preview",
-    "test-fixture": "custom-elements-v1",
-    "webcomponentsjs": "v1"
-  },
-  "ignore": []
+    "test-fixture": "custom-elements-v1"
+  }
 }

--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
     "iron-component-page": "PolymerElements/iron-component-page#2.0-preview",
     "test-fixture": "PolymerElements/test-fixture#^3.0.0-rc.1",
     "web-component-tester": "^6.0.0-prerelease.6",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#v1"
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0-rc.1"
   },
   "variants": {
     "1.x": {

--- a/bower.json
+++ b/bower.json
@@ -27,6 +27,19 @@
     "web-component-tester": "^4.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#v1"
   },
+  "variants": {
+    "1.x": {
+      "dependencies": {
+        "polymer": "Polymer/polymer#^1.0.0"
+      },
+      "devDependencies": {
+        "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
+        "test-fixture": "PolymerElements/test-fixture#^1.0.0",
+        "web-component-tester": "^4.0.0",
+        "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
+      }
+    }
+  },
   "resolutions": {
     "polymer": "2.0-preview",
     "test-fixture": "custom-elements-v1",

--- a/bower.json
+++ b/bower.json
@@ -23,8 +23,8 @@
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#2.0-preview",
-    "test-fixture": "PolymerElements/test-fixture#^2.0.0",
-    "web-component-tester": "v6.0.0-prerelease.5",
+    "test-fixture": "PolymerElements/test-fixture#^3.0.0-rc.1",
+    "web-component-tester": "^6.0.0-prerelease.6",
     "webcomponentsjs": "webcomponents/webcomponentsjs#v1"
   },
   "variants": {
@@ -40,8 +40,5 @@
       }
     }
   },
-  "ignore": [],
-  "resolutions": {
-    "test-fixture": "^2.0.0"
-  }
+  "ignore": []
 }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "iron-resizable-behavior",
-  "version": "1.0.5",
+  "version": "2.0.0",
   "license": "http://polymer.github.io/LICENSE.txt",
   "description": "Coordinates the flow of resizeable elements",
   "private": true,
@@ -19,13 +19,18 @@
     "url": "git://github.com/PolymerElements/iron-resizable-behavior.git"
   },
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.1.0"
+    "polymer": "https://github.com/PolymerLabs/alacarte.git#master"
   },
   "devDependencies": {
-    "iron-component-page": "polymerelements/iron-component-page#^1.0.0",
-    "test-fixture": "polymerelements/test-fixture#^1.0.0",
+    "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
+    "test-fixture": "PolymerElements/test-fixture#ce-v1",
     "web-component-tester": "^4.0.0",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
+    "webcomponentsjs": "webcomponents/webcomponentsjs#v1-polymer-edits"
+  },
+  "resolutions": {
+    "polymer": "master",
+    "test-fixture": "ce-v1",
+    "webcomponentsjs": "v1-polymer-edits"
   },
   "ignore": []
 }

--- a/bower.json
+++ b/bower.json
@@ -23,13 +23,13 @@
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
-    "test-fixture": "PolymerElements/test-fixture#ce-v1",
+    "test-fixture": "PolymerElements/test-fixture#custom-elements-v1",
     "web-component-tester": "^4.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#v1-polymer-edits"
   },
   "resolutions": {
     "polymer": "master",
-    "test-fixture": "ce-v1",
+    "test-fixture": "custom-elements-v1",
     "webcomponentsjs": "v1-polymer-edits"
   },
   "ignore": []

--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
     "url": "git://github.com/PolymerElements/iron-resizable-behavior.git"
   },
   "dependencies": {
-    "polymer": "Polymer/polymer#2.0-preview"
+    "polymer": "Polymer/polymer#^2.0.0-rc.1"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#2.0-preview",

--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#2.0-preview",
-    "test-fixture": "PolymerElements/test-fixture#custom-elements-v1",
+    "test-fixture": "PolymerElements/test-fixture#^2.0.0",
     "web-component-tester": "^4.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#v1"
   },
@@ -42,6 +42,6 @@
   },
   "ignore": [],
   "resolutions": {
-    "test-fixture": "custom-elements-v1"
+    "test-fixture": "^2.0.0"
   }
 }

--- a/iron-resizable-behavior.html
+++ b/iron-resizable-behavior.html
@@ -70,6 +70,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (!this._parentResizable) {
         window.addEventListener('resize', this._boundNotifyResize);
         this.notifyResize();
+        // NOTE(valdrin) In CustomElements v1, the order of imports affects the
+        // order of `attached` callbacks (see webcomponents/custom-elements#15).
+        // This might cause a child to notify parents too early (as the parent
+        // still has to be upgraded), resulting in a parent not able to keep track
+        // of the `_interestedResizables`. We send again the same event after
+        // after the next animation frame, when the imports are completed.
+        window.requestAnimationFrame(function() {
+          this.fire('iron-request-resize-notifications', null, {
+            node: this,
+            bubbles: true,
+            cancelable: true
+          });
+        }.bind(this));
       }
     },
 
@@ -192,4 +205,3 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
   };
 </script>
-

--- a/iron-resizable-behavior.html
+++ b/iron-resizable-behavior.html
@@ -79,6 +79,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         bubbles: true,
         cancelable: true
       });
+
       if (!this._parentResizable) {
         window.addEventListener('resize', this._boundNotifyResize);
         this.notifyResize();
@@ -154,8 +155,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // NOTE(cdata): In ShadowDOM, event retargetting makes echoing of the
       // otherwise non-bubbling event "just work." We do it manually here for
       // the case where Polymer is not using shadow roots for whatever reason:
-      // TODO(valdrin) remove ShadyDOM check after polymer/polymer#4198 is fixed.
-      if (!Polymer.Settings.useShadow || (window.ShadyDOM && window.ShadyDOM.inUse)) {
+      if (!Polymer.Settings.useShadow) {
         this._fireResize();
       }
     },
@@ -172,6 +172,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       if (target === this) {
         return;
       }
+
       if (this._interestedResizables.indexOf(target) === -1) {
         this._interestedResizables.push(target);
         this.listen(target, 'iron-resize', '_onDescendantIronResize');

--- a/iron-resizable-behavior.html
+++ b/iron-resizable-behavior.html
@@ -61,29 +61,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     attached: function() {
-      this.fire('iron-request-resize-notifications', null, {
-        node: this,
-        bubbles: true,
-        cancelable: true
-      });
-
-      if (!this._parentResizable) {
-        window.addEventListener('resize', this._boundNotifyResize);
-        this.notifyResize();
-        // NOTE(valdrin) In CustomElements v1, the order of imports affects the
-        // order of `attached` callbacks (see webcomponents/custom-elements#15).
-        // This might cause a child to notify parents too early (as the parent
-        // still has to be upgraded), resulting in a parent not able to keep track
-        // of the `_interestedResizables`. We send again the same event after
-        // after the next animation frame, when the imports are completed.
-        window.requestAnimationFrame(function() {
-          this.fire('iron-request-resize-notifications', null, {
-            node: this,
-            bubbles: true,
-            cancelable: true
-          });
-        }.bind(this));
-      }
+      // NOTE(valdrin) In CustomElements v1, the order of imports affects the
+      // order of `attached` callbacks (see webcomponents/custom-elements#15).
+      // This might cause a child to notify parents too early (as the parent
+      // still has to be upgraded), resulting in a parent not able to keep track
+      // of the `_interestedResizables`. To solve this, we wait for the document
+      // to be done loading before firing the event.
+      this.__onDocumentLoaded(function() {
+        this.fire('iron-request-resize-notifications', null, {
+          node: this,
+          bubbles: true,
+          cancelable: true
+        });
+        if (!this._parentResizable) {
+          window.addEventListener('resize', this._boundNotifyResize);
+          this.notifyResize();
+        }
+      }.bind(this));
     },
 
     detached: function() {
@@ -202,6 +196,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this._notifyingDescendant = true;
       descendant.notifyResize();
       this._notifyingDescendant = false;
+    },
+
+    __onDocumentLoaded: function(callback) {
+      if (document.readyState !== 'loading') {
+        callback();
+      } else {
+        document.addEventListener('readystatechange', function onReadystatechange() {
+          document.removeEventListener('readystatechange', onReadystatechange);
+          callback();
+        });
+      }
     }
   };
 </script>

--- a/iron-resizable-behavior.html
+++ b/iron-resizable-behavior.html
@@ -61,23 +61,28 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     attached: function() {
-      // NOTE(valdrin) In CustomElements v1, the order of imports affects the
-      // order of `attached` callbacks (see webcomponents/custom-elements#15).
+      // NOTE(valdrin) In CustomElements v1 with native HTMLImports, the order
+      // of imports affects the order of `attached` callbacks (see webcomponents/custom-elements#15).
       // This might cause a child to notify parents too early (as the parent
       // still has to be upgraded), resulting in a parent not able to keep track
       // of the `_interestedResizables`. To solve this, we wait for the document
       // to be done loading before firing the event.
-      this.__onDocumentLoaded(function() {
-        this.fire('iron-request-resize-notifications', null, {
-          node: this,
-          bubbles: true,
-          cancelable: true
-        });
-        if (!this._parentResizable) {
-          window.addEventListener('resize', this._boundNotifyResize);
-          this.notifyResize();
-        }
-      }.bind(this));
+      if (document.readyState === 'loading') {
+        document.addEventListener('readystatechange', function readystatechanged(){
+          document.removeEventListener('readystatechange', readystatechanged);
+          this.isAttached && this.attached();
+        }.bind(this));
+        return;
+      }
+      this.fire('iron-request-resize-notifications', null, {
+        node: this,
+        bubbles: true,
+        cancelable: true
+      });
+      if (!this._parentResizable) {
+        window.addEventListener('resize', this._boundNotifyResize);
+        this.notifyResize();
+      }
     },
 
     detached: function() {
@@ -195,17 +200,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this._notifyingDescendant = true;
       descendant.notifyResize();
       this._notifyingDescendant = false;
-    },
-
-    __onDocumentLoaded: function(callback) {
-      if (document.readyState !== 'loading') {
-        callback();
-      } else {
-        document.addEventListener('readystatechange', function onReadystatechange() {
-          document.removeEventListener('readystatechange', onReadystatechange);
-          callback();
-        });
-      }
     }
   };
 </script>

--- a/iron-resizable-behavior.html
+++ b/iron-resizable-behavior.html
@@ -68,10 +68,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // of the `_interestedResizables`. To solve this, we wait for the document
       // to be done loading before firing the event.
       if (document.readyState === 'loading') {
-        document.addEventListener('readystatechange', function readystatechanged(){
+        var _this = this;
+        document.addEventListener('readystatechange', function readystatechanged() {
           document.removeEventListener('readystatechange', readystatechanged);
-          this.isAttached && this.attached();
-        }.bind(this));
+          _this.isAttached && _this.attached();
+        });
         return;
       }
       this.fire('iron-request-resize-notifications', null, {

--- a/iron-resizable-behavior.html
+++ b/iron-resizable-behavior.html
@@ -163,12 +163,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     _onIronRequestResizeNotifications: function(event) {
-      var target = event.path ? event.path[0] : event.target;
-
+      var target = Polymer.dom(event).rootTarget;
       if (target === this) {
         return;
       }
-
       if (this._interestedResizables.indexOf(target) === -1) {
         this._interestedResizables.push(target);
         this.listen(target, 'iron-resize', '_onDescendantIronResize');

--- a/iron-resizable-behavior.html
+++ b/iron-resizable-behavior.html
@@ -149,7 +149,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // NOTE(cdata): In ShadowDOM, event retargetting makes echoing of the
       // otherwise non-bubbling event "just work." We do it manually here for
       // the case where Polymer is not using shadow roots for whatever reason:
-      if (!Polymer.Settings.useShadow) {
+      // TODO(valdrin) remove ShadyDOM check after polymer/polymer#4198 is fixed.
+      if (!Polymer.Settings.useShadow || (window.ShadyDOM && window.ShadyDOM.inUse)) {
         this._fireResize();
       }
     },

--- a/test/basic.html
+++ b/test/basic.html
@@ -17,9 +17,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
-  <script src="../../test-fixture/test-fixture-mocha.js"></script>
 
-  <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../iron-resizable-behavior.html">
   <link rel="import" href="test-elements.html">
 

--- a/test/imports.html
+++ b/test/imports.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<html>
+
+<head>
+
+  <title>iron-resizable-behavior tests</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+
+  <link rel="import" href="x-resizable.html">
+  <link rel="import" href="x-resizer-parent.html">
+
+</head>
+
+<body>
+  <x-resizer-parent>
+    <x-resizable></x-resizable>
+  </x-resizer-parent>
+
+  <script>
+    suite('imports order', function() {
+      setup(function(done) {
+        window.requestAnimationFrame(function() {
+          setTimeout(function() {
+            done();
+          });
+        });
+      });
+      
+      test('resizable children and parent updated', function() {
+        var parent = document.querySelector('x-resizer-parent');
+        var child = parent.firstElementChild;
+        assert.deepEqual(parent._interestedResizables, [child], 'resizable children ok');
+        assert.equal(child._parentResizable, parent, 'resizable parent ok');
+      });
+    });
+  </script>
+</body>
+
+</html>

--- a/test/imports.html
+++ b/test/imports.html
@@ -31,14 +31,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script>
     suite('imports order', function() {
-      setup(function(done) {
-        window.requestAnimationFrame(function() {
-          setTimeout(function() {
-            done();
-          });
-        });
-      });
-      
       test('resizable children and parent updated', function() {
         var parent = document.querySelector('x-resizer-parent');
         var child = parent.firstElementChild;

--- a/test/index.html
+++ b/test/index.html
@@ -18,6 +18,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     WCT.loadSuites([
       'basic.html',
+      'imports.html',
       'iron-resizable-behavior.html',
       'basic.html?dom=shadow',
       'iron-resizable-behavior.html?dom=shadow'

--- a/test/index.html
+++ b/test/index.html
@@ -17,11 +17,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script>
     WCT.loadSuites([
-      'basic.html',
-      'imports.html',
-      'iron-resizable-behavior.html',
-      'basic.html?dom=shadow',
-      'iron-resizable-behavior.html?dom=shadow'
+      'basic.html?wc-shadydom=true&wc-ce=true', //shady
+      'imports.html?wc-shadydom=true&wc-ce=true', //shady
+      'iron-resizable-behavior.html?wc-shadydom=true&wc-ce=true', //shady
+      'basic.html?dom=shadow', //shadow
+      'imports.html?dom=shadow', //shadow
+      'iron-resizable-behavior.html?dom=shadow' //shadow
     ]);
   </script>
 

--- a/test/iron-resizable-behavior.html
+++ b/test/iron-resizable-behavior.html
@@ -17,9 +17,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
-  <script src="../../test-fixture/test-fixture-mocha.js"></script>
 
-  <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../iron-resizable-behavior.html">
   <link rel="import" href="test-elements.html">
 

--- a/test/iron-resizable-behavior.html
+++ b/test/iron-resizable-behavior.html
@@ -25,7 +25,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 </head>
 <body>
- 
+
   <test-fixture id="ResizableAndShadowBoundaries">
     <template>
       <x-light-resizable></x-light-resizable>

--- a/test/test-elements.html
+++ b/test/test-elements.html
@@ -8,27 +8,8 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <link rel="import" href="../iron-resizable-behavior.html">
-
-<script>
-
-  Polymer({
-
-    is: 'x-resizer-parent',
-
-    behaviors: [
-      Polymer.IronResizableBehavior
-    ],
-
-    listeners: {
-      'core-resize': 'resizeHandler'
-    },
-
-    resizeHandler: function() {
-    }
-
-  });
-
-</script>
+<link rel="import" href="x-resizer-parent.html">
+<link rel="import" href="x-resizable.html">
 
 <script>
 
@@ -42,36 +23,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       Polymer.IronResizableBehavior
     ],
 
-    listeners: {
-      'core-resize': 'resizeHandler'
-    },
-
-    resizeHandler: function() {
-    },
-
     resizerShouldNotify: function(el) {
       return (el == this.active);
-    }
-
-  });
-
-</script>
-
-<script>
-
-  Polymer({
-
-    is: 'x-resizable',
-
-    behaviors: [
-      Polymer.IronResizableBehavior
-    ],
-
-    listeners: {
-      'core-resize': 'resizeHandler'
-    },
-
-    resizeHandler: function() {
     }
 
   });

--- a/test/x-resizable.html
+++ b/test/x-resizable.html
@@ -1,0 +1,24 @@
+<!--
+@license
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<link rel="import" href="../iron-resizable-behavior.html">
+
+<script>
+
+  Polymer({
+
+    is: 'x-resizable',
+
+    behaviors: [
+      Polymer.IronResizableBehavior
+    ]
+
+  });
+
+</script>

--- a/test/x-resizer-parent.html
+++ b/test/x-resizer-parent.html
@@ -1,0 +1,24 @@
+<!--
+@license
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<link rel="import" href="../iron-resizable-behavior.html">
+
+<script>
+
+  Polymer({
+
+    is: 'x-resizer-parent',
+
+    behaviors: [
+      Polymer.IronResizableBehavior
+    ]
+
+  });
+
+</script>


### PR DESCRIPTION
- use `Polymer.dom(event).rootTarget` instead of `event.path[0]` (compatible with 1.x and 2.x, as in FF `event.path` is always undefined)
- work around the issue of imports conditioning the attached callbacks (see  https://github.com/webcomponents/custom-elements/issues/15) by triggering `iron-request-resize-notifications` after the document is done loading
- added test for testing the import (separated `x-resizable` and `x-resizable-parent` in separate files)