### PR TITLE
avoid calling attached multiple times

### DIFF
--- a/iron-resizable-behavior.html
+++ b/iron-resizable-behavior.html
@@ -61,30 +61,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     attached: function() {
-      // NOTE(valdrin) In CustomElements v1 with native HTMLImports, the order
-      // of imports affects the order of `attached` callbacks (see webcomponents/custom-elements#15).
-      // This might cause a child to notify parents too early (as the parent
-      // still has to be upgraded), resulting in a parent not able to keep track
-      // of the `_interestedResizables`. To solve this, we wait for the document
-      // to be done loading before firing the event.
-      if (document.readyState === 'loading') {
-        var _this = this;
-        document.addEventListener('readystatechange', function readystatechanged() {
-          document.removeEventListener('readystatechange', readystatechanged);
-          _this.isAttached && _this.attached();
-        });
-        return;
-      }
-      this.fire('iron-request-resize-notifications', null, {
-        node: this,
-        bubbles: true,
-        cancelable: true
-      });
-
-      if (!this._parentResizable) {
-        window.addEventListener('resize', this._boundNotifyResize);
-        this.notifyResize();
-      }
+      this._requestResizeNotifications();
     },
 
     detached: function() {
@@ -202,6 +179,36 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       this._notifyingDescendant = true;
       descendant.notifyResize();
       this._notifyingDescendant = false;
+    },
+    
+    _requestResizeNotifications: function() {
+      if (!this.isAttached)
+        return;
+      
+      // NOTE(valdrin) In CustomElements v1 with native HTMLImports, the order
+      // of imports affects the order of `attached` callbacks (see webcomponents/custom-elements#15).
+      // This might cause a child to notify parents too early (as the parent
+      // still has to be upgraded), resulting in a parent not able to keep track
+      // of the `_interestedResizables`. To solve this, we wait for the document
+      // to be done loading before firing the event.
+      if (document.readyState === 'loading') {
+        var _requestResizeNotifications = this._requestResizeNotifications.bind(this);
+        document.addEventListener('readystatechange', function readystatechanged() {
+          document.removeEventListener('readystatechange', readystatechanged);
+          _requestResizeNotifications();
+        });
+      } else {
+        this.fire('iron-request-resize-notifications', null, {
+          node: this,
+          bubbles: true,
+          cancelable: true
+        });
+
+        if (!this._parentResizable) {
+          window.addEventListener('resize', this._boundNotifyResize);
+          this.notifyResize();
+        } 
+      }
     }
   };
 </script>

--- a/iron-resizable-behavior.html
+++ b/iron-resizable-behavior.html
@@ -146,7 +146,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     },
 
     _onIronRequestResizeNotifications: function(event) {
-      var target = Polymer.dom(event).rootTarget;
+      var target = /** @type {!EventTarget} */ (Polymer.dom(event).rootTarget);
       if (target === this) {
         return;
       }


### PR DESCRIPTION
`attached` might be called twice for elements that implement IronResizableBehavior on Chrome.
This PR ensures we invoke again only `_requestResizeNotifications` instead of `attached`.