### PR TITLE
Fix #32 - Parent resizable fails to receive resize notification when under shadow DOM.

### DIFF
--- a/iron-resizable-behavior.html
+++ b/iron-resizable-behavior.html
@@ -153,12 +153,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         return;
       }
 
-      // NOTE(cdata): In ShadowDOM, event retargeting makes echoing of the
-      // otherwise non-bubbling event "just work." We do it manually here for
-      // the case where Polymer is not using shadow roots for whatever reason:
-      if (!Polymer.Settings.useShadow) {
-        this._fireResize();
+      // NOTE(cdata): "Don't need to trigger event manually in case of ShadowDOM is used and
+      // event is coming from local DOM because of event retargeting. Otherwise, we need to trigger it manually".
+      if (Polymer.Settings.useShadow && event.target.domHost === this) {
+        return;
       }
+      
+      this._fireResize();
     },
 
     _fireResize: function() {


### PR DESCRIPTION
In ShadowDom, trigger event manually in case of ShadowDOM is used and event is coming from light DOM. 

Fixes [https://github.com/PolymerElements/iron-resizable-behavior/issues/32](32)